### PR TITLE
fixed DataView constructor call for IE

### DIFF
--- a/src/util/BufferView.mjs
+++ b/src/util/BufferView.mjs
@@ -36,7 +36,7 @@ export class BufferView {
 			this.byteOffset = 0
 			this.byteLength = 0
 		} else if (arg instanceof ArrayBuffer) {
-			let dataView = new DataView(arg, offset, length)
+			let dataView = new DataView(arg, offset, length === undefined ? arg.byteLength : length)
 			this._swapDataView(dataView)
 		} else if (arg instanceof Uint8Array || arg instanceof DataView || arg instanceof BufferView) {
 			// Node.js Buffer is also instance of Uint8Array, but small ones are backed


### PR DESCRIPTION
Thank you for your great work!

When I call `exifr.orientation` with ArrayBuffer in IE11, a TypeError(`DataView operation access beyond specified buffer length`) is thrown.
Here is a sample repository.
https://github.com/homuler/exifr-dataview-poc

It seems that when DataView contructor is called with the 3rd argument `undefined`, the byteLength of the DataView becomes 0 in IE.

```js
// IE11
new DataView(buffer, 0, undefined);  // -> new DataView(buffer, 0, 0);
new DataView(buffer, 0); // -> new DataView(buffer, 0, buffer.byteLength);
```
