### PR TITLE
Fix "show all" for byte arrays in homepage

### DIFF
--- a/homepage/util.js
+++ b/homepage/util.js
@@ -18,7 +18,7 @@ export class ByteLimitValueConverter {
     toView(uint8arr, showAll) {
 		if (notDefined(uint8arr)) return
 		if (!(uint8arr instanceof Uint8Array)) return
-		if (showAll) return string
+		if (showAll) return uint8arr
 		return clipBytes(uint8arr, 60)
     }
 }


### PR DESCRIPTION
There is a bug in your homepage: "show all" causes an error for byte array values.

How to reproduce:
- Open [your homepage](https://mutiny.cz/exifr/)
- Enable "makerNote"
- Click on "Show all" for makerNote

Here is the stack:
```
aurelia.umd.js:1957 Uncaught ReferenceError: string is not defined
    at ByteLimitValueConverter.toView (util.js:21)
    at ValueConverter.evaluate (aurelia.umd.js:3253)
    at ChildInterpolationBinding.call (aurelia.umd.js:12572)
    at SetterObserver.callSubscribers (aurelia.umd.js:2395)
    at SetterObserver.call (aurelia.umd.js:5374)
    at TaskQueue._flushQueue (aurelia.umd.js:1991)
    at TaskQueue.flushMicroTaskQueue (aurelia.umd.js:2042)
    at MutationObserver.<anonymous> (aurelia.umd.js:1972)
```