### PR TITLE
fix: Firefox > 77 not checked for auto rotation

### DIFF
--- a/src/highlevel-api.mjs
+++ b/src/highlevel-api.mjs
@@ -103,6 +103,10 @@ if (typeof navigator === 'object') {
 		let [match, version] = ua.match(/Chrome\/(\d+)/)
 		if (Number(version) >= 81)
 			rotateCanvas = rotateCss = false
+	} else if (ua.includes('Firefox/')) {
+		let [match, version] = ua.match(/Firefox\/(\d+)/)
+    if (Number(version) >= 77)
+      rotateCanvas = rotateCss = false
 	}
 }
 


### PR DESCRIPTION
[Firefox since 77](https://bugzilla.mozilla.org/show_bug.cgi?id=1616169) has also supported the "helpful" new auto rotation the WHATWG added. This checks for the Firefox version next to the Chrome check.