### PR TITLE
Protect module scope from malformed iOS user agent

### DIFF
--- a/src/highlevel-api.mjs
+++ b/src/highlevel-api.mjs
@@ -92,12 +92,15 @@ export var rotateCss = true
 if (typeof navigator === 'object') {
 	let ua = navigator.userAgent
 	if (ua.includes('iPad') || ua.includes('iPhone')) {
-		let [match, major, minor] = ua.match(/OS (\d+)_(\d+)/)
-		let version = Number(major) + Number(minor) * 0.1
-		// before ios 13.4, orientation is needed for canvas
-		// since ios 13.4, the data passed to canvas is already rotated
-		rotateCanvas = version < 13.4
-		rotateCss = false
+		let matchArray = ua.match(/OS (\d+)_(\d+)/)
+		if (matchArray) {
+			let [match, major, minor] = matchArray
+			let version = Number(major) + Number(minor) * 0.1
+			// before ios 13.4, orientation is needed for canvas
+			// since ios 13.4, the data passed to canvas is already rotated
+			rotateCanvas = version < 13.4
+			rotateCss = false
+		}
 	}
 	if (ua.includes('Chrome/')) {
 		let [match, version] = ua.match(/Chrome\/(\d+)/)


### PR DESCRIPTION
This PR adds a test around the user agent check, so that it doesn't crash if the ua is malformed. We're seeing this in embedded web views of apps that just happen to have `iPad` or `iPhone` in their names. When it crashes, it crashes on require pretty catastrophically.

Example User-Agent that will crash when this module is loaded (e.g. via `@uppy`):

- `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) MyVeryImporantApp-iPad/1.22.0.3/13.7`