### PR TITLE
Add ExternalReader that delegates all reading to an external function

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,9 +625,16 @@ Default: `5`
 
 Max amount of subsequent chunks allowed to read in which exifr searches for data segments and blocks. I.e. failsafe that prevents from reading the whole file if it does not contain all of the segments or blocks requested in `options`.
 
-This limit is bypassed if multi-segment segments ocurs in the file and if [`options.multiSegment`](#optionsmultisegment) allows reading all of them.
+This limit is bypassed if multi-segment segments occurs in the file and if [`options.multiSegment`](#optionsmultisegment) allows reading all of them.
 
 *If the exif isn't found within N chunks (64\*5 = 320KB) it probably isn't in the file and it's not worth reading anymore.*
+
+#### `options.externalReader`
+Type: `function`
+<br>
+Default: `undefined`
+
+Async function that receives three parameters - `input`, `offset`, and `length` – and returns an `ArrayBuffer` containing the requested chunk from the input source. If `offset` is missing, `undefined`, or `null`, the function should return the whole file.
 
 ### Output format
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,6 +44,7 @@ interface Options extends FormatOptions {
 	firstChunkSize?: number,
 	chunkSize?: number,
 	chunkLimit?: number,
+	externalReader?: function,
 }
 
 interface IRotation {

--- a/src/bundles/lite.mjs
+++ b/src/bundles/lite.mjs
@@ -6,6 +6,7 @@ export default mini
 // File Readers
 import '../file-readers/UrlFetcher.mjs'
 import '../file-readers/BlobReader.mjs'
+import '../file-readers/ExternalReader.mjs'
 
 // File Parser
 import '../file-parsers/jpeg.mjs'

--- a/src/file-readers/ExternalReader.mjs
+++ b/src/file-readers/ExternalReader.mjs
@@ -1,0 +1,22 @@
+import {fileReaders} from '../plugins.mjs'
+import {ChunkedReader} from './ChunkedReader.mjs'
+
+export class ExternalReader extends ChunkedReader {
+
+	async readWhole() {
+		this.chunked = false
+		let arrayBuffer = await this.options.externalReader(this.input)
+		this._swapArrayBuffer(arrayBuffer)
+	}
+
+	async _readChunk(offset, length) {
+		let abChunk = await this.options.externalReader(this.input, offset, length)
+		if (typeof abChunk === 'undefined') return undefined
+		let bytesRead = abChunk.byteLength
+		if (bytesRead !== length) this.size = offset + bytesRead
+		return this.set(abChunk, offset, true)
+	}
+
+}
+
+fileReaders.set('external', ExternalReader)

--- a/src/reader.mjs
+++ b/src/reader.mjs
@@ -9,7 +9,9 @@ import {fileReaders} from './plugins.mjs'
 const INVALID_INPUT = 'Invalid input argument'
 
 export function read(arg, options) {
-	if (typeof arg === 'string')
+	if (options.externalReader && (typeof options.externalReader === 'function'))
+		return callReaderClass(arg, options, 'external')
+	else if (typeof arg === 'string')
 		return readString(arg, options)
 	else if (platform.browser && !platform.worker && arg instanceof HTMLImageElement)
 		return readString(arg.src, options)

--- a/test/reader.spec.mjs
+++ b/test/reader.spec.mjs
@@ -76,6 +76,20 @@ describe('reader', () => {
 			assert.isObject(output, `output is undefined`)
 		})
 
+		it(`ExternalReader`, async() => {
+			let called;
+
+			const externalReader = async (input, offset, length) => {
+				called = {input, offset, length};
+				let buffer = await getFile(input);
+				return buffer.slice(offset, length);
+			}
+						
+			var output = await exifr.parse('IMG_20180725_163423.jpg', {externalReader})
+			assert.isObject(output, `output is undefined`)
+			assert.isObject(called)
+		})
+
 		isNode && it(`Node: Buffer`, async () => {
 			var buffer = await fs.readFile(getPath('IMG_20180725_163423.jpg'))
 			var output = await exifr.parse(buffer)


### PR DESCRIPTION
## Description

This PR adds an option, `externalReader`, which takes over the task of reading files/chunks from the built-in readers.

### Example

In the following example, the input to exifr is an object pointing to a file stored in an Amazon S3 bucket. The custom reader function uses the AWS SDK to grab the chunks exifr needs. With this functionality, the input given to exifr can be literally _anything_, as long as the supplied `externalReader` function knows what to do with it.

```javascript
const AWS = require("aws-sdk");
const exifr = require("exifr");
const s3 = new AWS.S3();

function chunkReader(input, offset, length) {
  return new Promise((resolve, _reject) => {
    let params = {...input};

    if (typeof offset === 'number') {
      let end = length ? offset + length - 1 : undefined;
      params.Range = `bytes=${[offset, end].join('-')}`;
    }

    s3.getObject(params, (err, data) => {
      if (err) {
        console.error(err);
        resolve(undefined);
      } else {
        resolve(data.Body);
      }
    });
  });
}

exifr.parse({ Bucket: "my-aws-bucket", Key: "path/to/some.tif" }, { externalReader: chunkReader })
  .then((exif) => console.log(exif))
  .catch(err => reject(err));
```