### PR TITLE
Urls with query string are not working correctly. This fixes it.

### DIFF
--- a/src/polyfill/fetch-node.mjs
+++ b/src/polyfill/fetch-node.mjs
@@ -17,11 +17,11 @@ if (!global.fetch) {
 	const httpsPromise = dynamicImport('https', https => https)
 
 	setFetch(function(url, {headers} = {}) {
-		let {port, hostname, pathname, protocol} = new URL(url)
+		let {port, hostname, pathname, protocol, search} = new URL(url)
 		const options = {
 			method: 'GET',
 			hostname,
-			path: encodeURI(pathname),
+			path: encodeURI(pathname) + search,
 			headers
 		}
 		if (port !== '') options.port = Number(port)


### PR DESCRIPTION
I am getting 403 from aws s3 as query_string are not passed through in the node fetch polyfill.

With this PR, I am able to parse the exifs on files stored on AWS S3 with presigned_urls. (It is another but simpler use case of  #57)

From Node documentation:

path <string> Request path. Should include query string if any. E.G.
'/index.html?page=12'. An exception is thrown when the request path
contains illegal characters. Currently, only spaces are rejected but
that may change in the future. Default: '/'.

