### PR TITLE
Add an option to specify HTTP headers when fetching from URLs that re…

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,8 @@ let defaultOptions = {
   firstChunkSizeNode: 512,
   firstChunkSizeBrowser: 65536, // 64kb
   chunkSize: 65536, // 64kb
-  chunkLimit: 5
+  chunkLimit: 5,
+  httpHeaders: {},
 }
 ```
 
@@ -628,6 +629,14 @@ Max amount of subsequent chunks allowed to read in which exifr searches for data
 This limit is bypassed if multi-segment segments ocurs in the file and if [`options.multiSegment`](#optionsmultisegment) allows reading all of them.
 
 *If the exif isn't found within N chunks (64\*5 = 320KB) it probably isn't in the file and it's not worth reading anymore.*
+
+#### `options.httpHeaders`
+Type: `object`
+<br>
+Default: {}
+
+Additional HTTP headers to include when fetching chunks from URLs that require
+Authorization or other custom headers.
 
 ### Output format
 

--- a/src/file-readers/UrlFetcher.mjs
+++ b/src/file-readers/UrlFetcher.mjs
@@ -18,7 +18,7 @@ export class UrlFetcher extends ChunkedReader {
 	async _readChunk(offset, length) {
 		let end = length ? offset + length - 1 : undefined
 		// note: end in http range is inclusive, unlike APIs in node,
-		let headers = {}
+		let headers = this.options.httpHeaders || {};
 		if (offset || end) headers.range = `bytes=${[offset, end].join('-')}`
 		let res = await fetch(this.input, {headers})
 		let abChunk = await res.arrayBuffer()


### PR DESCRIPTION
…quire authorization or other customer headers

We've been using this for fetching image metadata for files in Box, Dropbox, and S3.