### PR TITLE
Add multiSegment in types format options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ interface FormatOptions {
 	translateValues?: boolean,
 	reviveValues?: boolean,
 	parse?: boolean, // XMP only
+	multiSegment?: boolean, // XMP and icc only
 }
 
 interface Options extends FormatOptions {


### PR DESCRIPTION
Base on the [docs](https://www.npmjs.com/package/exifr#optionsmultisegment), there should be an options `multiSegment` but the type in the options is not provided.